### PR TITLE
Skip text nodes in search for table header

### DIFF
--- a/lib/rules/table-req-header.js
+++ b/lib/rules/table-req-header.js
@@ -16,8 +16,12 @@ module.exports.lint = function (ele, opts) {
         child;
 
     //ffwd to first relevant table child
-    while ((child = children[childIndex]) && child.name &&
-           child.name.match(/(caption|colgroup|tfoot)/i)) {
+    while ((child = children[childIndex]) && 
+        (
+            child.name === undefined || // skip text nodes
+            (child.name && child.name.match(/(caption|colgroup)/i))
+        )
+    ) {
         childIndex++;
     }
 

--- a/lib/rules/table-req-header.js
+++ b/lib/rules/table-req-header.js
@@ -25,11 +25,17 @@ module.exports.lint = function (ele, opts) {
         childIndex++;
     }
 
-    if (child && child.name &&
-        ((child.name.match(/thead/i)) ||
-         (child.name.match(/tr/i) && child.children[0].name.match(/th/i)))
-       ) {
+    if (child && child.name && child.name.match(/thead/i)) {
         return [];
+    }
+
+    if (child && child.name && child.name.match(/tr/i)) {
+        // Check if any child in first row is `<th>`, not just first child (which could be a text node)
+        for (var i=0, l=child.children.length; i<l; i++) {
+            if (child.children[i].name && child.children[i].name == 'th') {
+                return []
+            }
+        }
     }
 
     return new Issue('E035', ele.openLineCol);

--- a/test/functional/table-req-header.js
+++ b/test/functional/table-req-header.js
@@ -17,6 +17,12 @@ module.exports = [
         opts: { 'table-req-header': true },
         output: 0
     },
+	{
+        desc: 'should pass when th is not first cell in tr',
+        input: '<table><tr><td>Shh</td><th>Doges</th></tr></table>',
+        opts: { 'table-req-header': true },
+        output: 0
+    },
     {
         desc: 'should fail when th not encapsulated in a tr because that\'s technically not valid',
         input: '<table><th>Dog</th></table>',
@@ -30,14 +36,26 @@ module.exports = [
         output: 1
     },
     {
-        desc: 'should pass when table has captions and stuff',
+        desc: 'should pass when table has caption and th',
         input: '<table><caption>DOGS</caption><tr><th>Hey</th></tr></table>',
         opts: { 'table-req-header': true },
         output: 0
     },
     {
-        desc: 'should pass when table has captions and thead',
+        desc: 'should pass when table has caption and thead',
         input: '<table><caption>DOGS</caption><thead>Hey</thead></table>',
+        opts: { 'table-req-header': true },
+        output: 0
+    },
+	{
+        desc: 'should pass when table has caption and text before thead',
+        input: '<table>\n\t<caption>DOGS</caption>\n  <thead></thead>\n</table>',
+        opts: { 'table-req-header': true },
+        output: 0
+    },
+    {
+        desc: 'should pass when table has caption and text before th',
+        input: '<table>\n\t<caption>DOGS</caption>\n  <tr>\n\t  <td>Shh</td>\n  \t<th>Doges</th>\n  </tr>\n</table>',
         opts: { 'table-req-header': true },
         output: 0
     }


### PR DESCRIPTION
Text nodes are messing with our counting to find the first `<thead>` or `<tr>`

Also:
* The [living standard](https://html.spec.whatwg.org/multipage/tables.html#the-table-element) says that `<tfoot>` needs to follow the body. If we ignore this content model detail, then we would need to expand our counting to also include `<tbody>` and `<tr>`
* The first child of our first `<tr>` could also be a text node, or maybe the developer wants to intermix `<td>` with `<th>`, so we need to search all children in the row until we find the `<th>`